### PR TITLE
Reindent .travis.yml for improved readability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,67 @@
 language: python
 python:
-- pypy
-- 2.7
-- pypy3
-- 3.4
-- 3.5
-- 3.6
+  - pypy
+  - 2.7
+  - pypy3
+  - 3.4
+  - 3.5
+  - 3.6
+
 env:
-- SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
-- SQLALCHEMY_VER=">=1.0.0,<1.1.0" PIP_OPTS=""
-- SQLALCHEMY_VER=">=1.1.0,<1.2.0" PIP_OPTS=""
-- SQLALCHEMY_VER=">=1.2.0,<1.3.0" PIP_OPTS=""
+  - SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
+  - SQLALCHEMY_VER=">=1.0.0,<1.1.0" PIP_OPTS=""
+  - SQLALCHEMY_VER=">=1.1.0,<1.2.0" PIP_OPTS=""
+  - SQLALCHEMY_VER=">=1.2.0,<1.3.0" PIP_OPTS=""
+
 matrix:
   exclude:
-  # SQLAlchemy < 1.0.0 does not support psycopg2cffi as required by pypy
-  - python: pypy
-    env: SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
-  - python: pypy3
-    env: SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
+    # SQLAlchemy < 1.0.0 does not support psycopg2cffi as required by pypy
+    - python: pypy
+      env: SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
+    - python: pypy3
+      env: SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
+
 services:
-- postgresql
-- mysql
+  - postgresql
+  - mysql
+
 before_install:
-- export PY=`python -c 'import sys; print("pypy" if hasattr(sys,"pypy_version_info") else "%d.%d" % sys.version_info[:2])'`
-- export PY_VER=`python -c 'import sys; print("%d.%d" % sys.version_info[:2])'`
-- echo "PY='$PY'"
-- echo "PY_VER='$PY_VER'"
-- if [[ "$PY" = "pypy" ]]; then
-    export PG_URL="postgresql+psycopg2cffi:///utc_test";
-    export MYSQL_URL="mysql+pymysql://root@localhost/utc_test";
-  else
-    export PG_URL="postgresql+psycopg2:///utc_test";
-    export MYSQL_URL="mysql+mysqlconnector://root@localhost/utc_test";
-  fi
-- export TEST_DATABASE_URLS="$PG_URL $MYSQL_URL"
+  - export PY=`python -c 'import sys; print("pypy" if hasattr(sys,"pypy_version_info") else "%d.%d" % sys.version_info[:2])'`
+  - export PY_VER=`python -c 'import sys; print("%d.%d" % sys.version_info[:2])'`
+  - echo "PY='$PY'"
+  - echo "PY_VER='$PY_VER'"
+  - if [[ "$PY" = "pypy" ]]; then
+      export PG_URL="postgresql+psycopg2cffi:///utc_test";
+      export MYSQL_URL="mysql+pymysql://root@localhost/utc_test";
+    else
+      export PG_URL="postgresql+psycopg2:///utc_test";
+      export MYSQL_URL="mysql+mysqlconnector://root@localhost/utc_test";
+    fi
+  - export TEST_DATABASE_URLS="$PG_URL $MYSQL_URL"
+
 install:
-- if [[ "$PIP_OPTS" != "" ]]; then
-    pip install $PIP_OPTS "SQLAlchemy $SQLALCHEMY_VER";
-  else
-    pip install "SQLAlchemy $SQLALCHEMY_VER";
-  fi
-- pip install -e .
-- pip install pytest flake8 "import-order >= 0.0.10"
-- pip install pytest-cov codecov
-- if [[ "$PY" = "pypy" ]]; then
-    pip install psycopg2cffi pymysql;
-  else
-    pip install psycopg2 mysql-connector-python;
-  fi
+  - if [[ "$PIP_OPTS" != "" ]]; then
+      pip install $PIP_OPTS "SQLAlchemy $SQLALCHEMY_VER";
+    else
+      pip install "SQLAlchemy $SQLALCHEMY_VER";
+    fi
+  - pip install -e .
+  - pip install pytest flake8 "import-order >= 0.0.10"
+  - pip install pytest-cov codecov
+  - if [[ "$PY" = "pypy" ]]; then
+      pip install psycopg2cffi pymysql;
+    else
+      pip install psycopg2 mysql-connector-python;
+    fi
+
 before_script:
-- createdb -E utf8 -T postgres utc_test
-- mysql -e 'CREATE DATABASE utc_test;'
+  - createdb -E utf8 -T postgres utc_test
+  - mysql -e 'CREATE DATABASE utc_test;'
+
 script:
-- pytest --cov=. --durations=10 test.py
-- flake8 .
-- pip uninstall -y SQLAlchemy-Utc && import-order --only-file sqlalchemy_utc.py test.py
+  - pytest --cov=. --durations=10 test.py
+  - flake8 .
+  - pip uninstall -y SQLAlchemy-Utc && import-order --only-file sqlalchemy_utc.py test.py
+
 after_success:
-- codecov
+  - codecov


### PR DESCRIPTION
This PR reindents `.travis.yml` as well as adding additional new lines in order to improve the visual scoping of sections and overall readability.

The diff will be best viewed with whitespace ignored: [?w=1](https://github.com/spoqa/sqlalchemy-utc/pull/5/files?w=1)