### PR TITLE
ensure the datetime returned to the user is always UTC

### DIFF
--- a/sqlalchemy_utc/sqltypes.py
+++ b/sqlalchemy_utc/sqltypes.py
@@ -31,6 +31,9 @@ class UtcDateTime(TypeDecorator):
             return value.astimezone(utc)
 
     def process_result_value(self, value, dialect):
-        if value is not None and value.tzinfo is None:
-            value = value.replace(tzinfo=utc)
+        if value is not None:
+            if value.tzinfo is None:
+                value = value.replace(tzinfo=utc)
+            else:
+                value = value.astimezone(utc)
         return value


### PR DESCRIPTION
Always convert datetime returned from database to UTC before returning it to the user.

Fixes https://github.com/spoqa/sqlalchemy-utc/issues/6 