### PR TITLE
Make package is PEP-561 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
     version=get_version(),
     url='https://github.com/spoqa/sqlalchemy-utc',
     packages=find_packages(exclude=('tests*',)),
+    package_data={'sqlalchemy_utc': ['py.typed']},
     author='Hong Minhee',
     author_email='hongminhee' '@' 'member.fsf.org',
     license='MIT License',


### PR DESCRIPTION
[PEP-561](https://www.python.org/dev/peps/pep-0561/) describes which typing information might contain package and how to deal with it. Because sqlalchemy-utc doesn't distributed with `py.typed` file — mypy and other typing checkers cannot "safely" read it.

In few cases it can lead to problems, in my case sqlalchemy-stubs2 cannot infer type from field with UtcDateTime and raise errors like `unexpected field in instance init`.

This PR adds `py.typed` to package, so mypy can read from it and do all magic around it.