### PR TITLE
Add milliseconds to SQLite datetimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ install:
 - pip install pytest codecov flake8 flake8-import-order
 # pytest-cov 2.10.0 requires a pytest >= 4.6 which is not available in the Python 2.7 environment.
 # Use an older version for it.
-- if [[ "$PY_VER" = "2.7" -a "$PY" != "pypy" ]]; then
+- if [[ "$PY_VER" = "2.7" && "$PY" != "pypy" ]]; then
     pip install 'pytest-cov < 2.10.0';
   else
     pip install pytest-cov;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,30 @@
 language: python
 python:
-- pypy
-- 2.7
+# Supported versions
 - pypy3
-- 3.4
-- 3.5
 - 3.6
 - 3.7
 - 3.8
 - 3.9
+- pypy
+# Unsupported from Python team
+- 2.7
+# Completely unsupported
+- 3.4
+- 3.5
+# See:
+# https://www.python.org/downloads/
+# https://www.pypy.org/download_advanced.html
 
 env:
+# Supported versions
+- SQLALCHEMY_VER=">=1.3.0,<1.4.0" PIP_OPTS=""
+- SQLALCHEMY_VER=">=1.4.0,<1.5.0" PIP_OPTS=""
+# Unsupported versions
 - SQLALCHEMY_VER=">=1.0.0,<1.1.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.1.0,<1.2.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.2.0,<1.3.0" PIP_OPTS=""
-- SQLALCHEMY_VER=">=1.3.0,<1.4.0" PIP_OPTS=""
-- SQLALCHEMY_VER=">=1.4.0,<1.5.0" PIP_OPTS=""
+# See: https://www.sqlalchemy.org/download.html
 
 services:
 - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,14 @@ services:
 - postgresql
 - mysql
 
+jobs:
+  exclude:
+    # No package of SQLAlchemy v1.4 for these Python versions
+    - python: 3.4
+      env: SQLALCHEMY_VER=">=1.4.0,<1.5.0" PIP_OPTS=""
+    - python: 3.5
+      env: SQLALCHEMY_VER=">=1.4.0,<1.5.0" PIP_OPTS=""
+
 before_install:
 - export PY=`python -c 'import sys; print("pypy" if hasattr(sys,"pypy_version_info") else "%d.%d" % sys.version_info[:2])'`
 - export PY_VER=`python -c 'import sys; print("%d.%d" % sys.version_info[:2])'`
@@ -42,7 +50,14 @@ install:
     pip install "SQLAlchemy $SQLALCHEMY_VER";
   fi
 - pip install -e .
-- pip install pytest pytest-cov codecov flake8 flake8-import-order
+- pip install pytest codecov flake8 flake8-import-order
+# pytest-cov 2.10.0 requires a pytest >= 4.6 which is not available in the Python 2.7 environment.
+# Use an older version for it.
+- if [[ "$PY_VER" = "2.7" -a "$PY" != "pypy" ]]; then
+    pip install 'pytest-cov < 2.10.0';
+  else
+    pip install pytest-cov;
+  fi
 # PyMySQL dropped support for Python 2.7 in version 1.0.0:
 # https://github.com/PyMySQL/PyMySQL/blob/master/CHANGELOG.md#v100
 # mysql-coonector-python did the same since version 8.0.24:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,17 @@ python:
 - 3.4
 - 3.5
 - 3.6
+- 3.7
+- 3.8
+- 3.9
 
 env:
 - SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.0.0,<1.1.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.1.0,<1.2.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.2.0,<1.3.0" PIP_OPTS=""
+- SQLALCHEMY_VER=">=1.3.0,<1.4.0" PIP_OPTS=""
+- SQLALCHEMY_VER=">=1.4.0,<1.5.0" PIP_OPTS=""
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,11 @@ python:
 - 3.9
 
 env:
-- SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.0.0,<1.1.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.1.0,<1.2.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.2.0,<1.3.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.3.0,<1.4.0" PIP_OPTS=""
 - SQLALCHEMY_VER=">=1.4.0,<1.5.0" PIP_OPTS=""
-
-matrix:
-  exclude:
-  # SQLAlchemy < 1.0.0 does not support psycopg2cffi as required by pypy
-  - python: pypy
-    env: SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
-  - python: pypy3
-    env: SQLALCHEMY_VER=">=0.9.0,<1.0.0" PIP_OPTS=""
 
 services:
 - postgresql
@@ -51,10 +42,15 @@ install:
     pip install "SQLAlchemy $SQLALCHEMY_VER";
   fi
 - pip install -e .
-- pip install pytest flake8 flake8-import-order
-- pip install pytest-cov codecov
+- pip install pytest pytest-cov codecov flake8 flake8-import-order
+# PyMySQL dropped support for Python 2.7 in version 1.0.0:
+# https://github.com/PyMySQL/PyMySQL/blob/master/CHANGELOG.md#v100
+# mysql-coonector-python did the same since version 8.0.24:
+# https://dev.mysql.com/doc/connector-python/en/connector-python-versions.html
 - if [[ "$PY" = "pypy" ]]; then
-    pip install psycopg2cffi pymysql;
+    pip install psycopg2cffi 'pymysql < 1.0.0';
+  elif [[ "$PY_VER" = "2.7" ]]; then
+    pip install psycopg2 'mysql-connector-python < 8.0.24';
   else
     pip install psycopg2 mysql-connector-python;
   fi

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,10 @@ SQLAlchemy-Utc
 
 .. image:: https://badge.fury.io/py/SQLAlchemy-Utc.svg?
    :target: https://pypi.python.org/pypi/SQLAlchemy-Utc
-.. image:: https://travis-ci.com/ItachiSan/sqlalchemy-utc.svg?branch=master
-   :target: https://travis-ci.com/ItachiSan/sqlalchemy-utc
-.. image:: https://codecov.io/github/ItachiSan/sqlalchemy-utc/coverage.svg?branch=master
-   :target: https://codecov.io/github/ItachiSan/sqlalchemy-utc?branch=master
+.. image:: https://travis-ci.com/spoqa/sqlalchemy-utc.svg?branch=master
+   :target: https://travis-ci.com/spoqa/sqlalchemy-utc
+.. image:: https://codecov.io/github/spoqa/sqlalchemy-utc/coverage.svg?branch=master
+   :target: https://codecov.io/github/spoqa/sqlalchemy-utc?branch=master
 
 This package provides a drop-in replacement of SQLAlchemy's built-in `DateTime`_
 type with ``timezone=True`` option enabled.  Although SQLAlchemy's built-in

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,10 @@ SQLAlchemy-Utc
 
 .. image:: https://badge.fury.io/py/SQLAlchemy-Utc.svg?
    :target: https://pypi.python.org/pypi/SQLAlchemy-Utc
-.. image:: https://travis-ci.org/spoqa/sqlalchemy-utc.svg?branch=master
-   :target: https://travis-ci.org/spoqa/sqlalchemy-utc
-.. image:: https://codecov.io/github/spoqa/sqlalchemy-utc/coverage.svg?branch=master
-   :target: https://codecov.io/github/spoqa/sqlalchemy-utc?branch=master
+.. image:: https://travis-ci.com/ItachiSan/sqlalchemy-utc.svg?branch=master
+   :target: https://travis-ci.com/ItachiSan/sqlalchemy-utc
+.. image:: https://codecov.io/github/ItachiSan/sqlalchemy-utc/coverage.svg?branch=master
+   :target: https://codecov.io/github/ItachiSan/sqlalchemy-utc?branch=master
 
 This package provides a drop-in replacement of SQLAlchemy's built-in `DateTime`_
 type with ``timezone=True`` option enabled.  Although SQLAlchemy's built-in

--- a/sqlalchemy_utc/now.py
+++ b/sqlalchemy_utc/now.py
@@ -34,7 +34,12 @@ def mysql_sql_utcnow(element, compiler, **kw):
 
 @compiles(utcnow, 'sqlite')
 def sqlite_sql_utcnow(element, compiler, **kw):
-    return "(DATETIME('NOW'))"
+    """SQLite DATETIME('NOW') returns a correct `datetime.datetime` but does not
+    add milliseconds to it.
+
+    Directly call STRFTIME with the final %f modifier in order to get those.
+    """
+    return r"(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))"
 
 
 @compiles(utcnow, 'mssql')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy, py27, pypy3, py34, py35, py36
+envlist = pypy, py27, pypy3, py34, py35, py36, py37, py38, py39
 minversion = 1.6.0
 
 [testenv]


### PR DESCRIPTION
The SQLite DATETIME() method does not provide milliseconds nor has a switch for toggling them.
This is overall inconvenient.
By calling correctly STRFTIME(), we can have the milliseconds information appropriately added.

In addition, the CI configuration file was updated to support newer Python and SQLAlchemy versions.