### PR TITLE
added cache_ok flag to supress Pandas warnings

### DIFF
--- a/sqlalchemy_utc/sqltypes.py
+++ b/sqlalchemy_utc/sqltypes.py
@@ -20,6 +20,7 @@ class UtcDateTime(TypeDecorator):
     """
 
     impl = DateTime(timezone=True)
+    cache_ok = True
 
     def process_bind_param(self, value, dialect):
         if value is not None:


### PR DESCRIPTION
According to this explanation: 
https://docs.sqlalchemy.org/en/14/core/custom_types.html#sqlalchemy.types.TypeDecorator.cache_ok

The type decorator should be safe for setting cache_ok=True, since we have a stateless and functional conversion