### PR TITLE
Added `inherit_cache` to utcnow

### DIFF
--- a/sqlalchemy_utc/now.py
+++ b/sqlalchemy_utc/now.py
@@ -7,6 +7,7 @@ from .sqltypes import UtcDateTime
 
 class utcnow(FunctionElement):
     """UTCNOW() expression for multiple dialects."""
+
     inherit_cache = True
     type = UtcDateTime()
 

--- a/sqlalchemy_utc/now.py
+++ b/sqlalchemy_utc/now.py
@@ -7,6 +7,7 @@ from .sqltypes import UtcDateTime
 
 class utcnow(FunctionElement):
     """UTCNOW() expression for multiple dialects."""
+    inherit_cache = True
     type = UtcDateTime()
 
 


### PR DESCRIPTION
getting this error from sqlalchemy 1.4:
```
SAWarning: Class utcnow will not make use of SQL compilation caching as it does not set the 'inherit_cache' attribute to ``True``.  This can have significant performance implications including some performance degradations in comparison to prior SQLAlchemy versions.  Set this attribute to True if this object can make use of the cache key generated by the superclass.  Alternatively, this attribute may be set to False which will disable this warning. (Background on this error at: https://sqlalche.me/e/14/cprf)
```